### PR TITLE
Edited Line 8

### DIFF
--- a/docs/source/general/docker-deployment.rst
+++ b/docs/source/general/docker-deployment.rst
@@ -5,7 +5,7 @@ Openchain Server Docker deployment
 
 Openchain Server is cross platform and can be deployed as a `DNX application <https://dotnet.readthedocs.org/en/latest/dnx/overview.html>`_ on Windows, OS X and Linux. However, to simplify dependency management and homogenize deployment of Openchain, we are shipping it as a Docker image.
 
-This document explain the few steps necessary to have the Openchain server running.
+This document explains the few steps necessary to have the Openchain server running. Refer to the `next section <https://docs.openchain.org/en/latest/general/running-openchain.html>`_ to deploy Openchain directly.
 
 Install Docker
 --------------


### PR DESCRIPTION
Corrected the grammar of the pre-existing sentence (line 8), and mentioned that the option to deploy without the Docker is an option available in the next page. It was mildly amusing/annoying that I only found out about this _after_ deploying on Docker.
